### PR TITLE
Update -bg/-fg/-attr to new -style format

### DIFF
--- a/home/dot_tmux.conf
+++ b/home/dot_tmux.conf
@@ -17,21 +17,16 @@ bind % split-window -h -c "#{pane_current_path}"
 bind '"' split-window -v -c "#{pane_current_path}"
 
 # Look and feel:
-set-option -g status-bg colour235
-set-option -g status-fg colour136
-set-option -g status-attr default
-set-option -g message-bg colour235
-set-option -g message-fg colour166
+set-option -g status-style default,bg=colour235,fg=colour136
+set-option -g message-style bg=colour235,fg=colour166
 set-window-option -g window-status-format '#[fg=colour244] #I:#W '
 set-window-option -g window-status-current-format '#[fg=colour166][#I:#W]'
 setw -g monitor-activity on
 set -g visual-activity on
-set-window-option -g window-status-activity-bg default
-set-window-option -g window-status-activity-fg default
-set-window-option -g window-status-activity-attr bright
+set-window-option -g window-status-activity-style bg=default,fg=default,bright
 
-set-option -g pane-border-fg colour235
-set-option -g pane-active-border-fg colour100
+set-option -g pane-border-style fg=colour235
+set-option -g pane-active-border-style fg=colour100
 set-option -g mode-fg colour235
 set-option -g mode-bg colour100
 set-option -g display-panes-colour colour166


### PR DESCRIPTION
The -bg/-fg/-attr were deprecated in tmux v1.9 (superseded by -style options) and have been removed as of v2.9.
